### PR TITLE
Fix Folia compatibility: Use teleportAsync and entity scheduler

### DIFF
--- a/src/main/java/zoruafan/foxaddition/checks/mechanics/Position.java
+++ b/src/main/java/zoruafan/foxaddition/checks/mechanics/Position.java
@@ -50,7 +50,11 @@ public class Position extends FoxPlayer implements Listener {
         if ((e.isInsideVehicle() && !e.getVehicle().isValid()) && api.getFiles().getAC().getBoolean(p+".invalidvehicle", true)) {
         	flag(false, e, "Moved in invalid vehicle!", "Mechanics [Position]", "[inside:"+e.isInsideVehicle()+"] [isValid:"+e.getVehicle().isValid()+"]", 0, "mechanics");
         	ev.setCancelled(true);
-        	e.teleport(oldL);
+        	if (FoliaScheduler.isFolia()) {
+        		e.teleportAsync(oldL);
+        	} else {
+        		e.teleport(oldL);
+        	}
         	try { e.getVehicle().eject(); } catch (Exception p) {}
         	return;
         } else if ((!e.isValid() && !e.isDead()) && api.getFiles().getAC().getBoolean(p+".invalidmove", true)) {
@@ -74,11 +78,15 @@ public class Position extends FoxPlayer implements Listener {
         double additional = api.getFiles().getAC().getDouble(p+".pullback.nosprint", 1.08);
         if(e.isSprinting()) additional = (additional+api.getFiles().getAC().getDouble(p+".pullback.sprint", .31));
         if(((y-1.00 == oldY || y > oldY+additional || oldY-y == api.getFiles().getAC().getDouble(p+".pullback.default", -1.0)) && (e.getGameMode() == GameMode.SURVIVAL || e.getGameMode() == GameMode.ADVENTURE && (!e.isFlying() && !e.getAllowFlight()))) && !iAD(e, "mechanics", p+".pullback", true)) { 
-        	boolean de = true;
+        	bif (FoliaScheduler.isFolia()) {
+	        		FoliaScheduler.getGlobalRegionScheduler().run(api.getPlugin(), (FA) -> e.teleportAsync(oldL));
+	        	} else {
+	        		FoliaScheduler.getGlobalRegionScheduler().run(api.getPlugin(), (FA) -> e.teleport(oldL));
+	        	}
         	if(api.getFiles().getAC().getBoolean(p+".pullback.ignore_velocity", true)) { if(e.getVelocity().getX() > 0.0 || e.getVelocity().getY() > 0.0 || e.getVelocity().getZ() > 0.0) { de = false; } }
         	if(de) {
 	        	flag(true, e, "Detected using PullBack!", "Mechanics [Position]", "[Y:"+oldY+"/"+y+"] [diff:"+(oldY-y)+"]", 0, "mechanics");
-	        	FoliaScheduler.getGlobalRegionScheduler().run(api.getPlugin(), (FA) -> e.teleport(oldL));
+	        	FoliaScheduler.getGlobalRegionScheduler().run(api.getPlugin(), (FA) -> e.teleportAsync(oldL));
 	        	ev.setCancelled(true);
 	        	return;
         	}
@@ -105,11 +113,15 @@ public class Position extends FoxPlayer implements Listener {
     		return;
     	} else if((oldY+api.getFiles().getAC().getInt(p+".checks.fast.y", 45) < y || oldX+api.getFiles().getAC().getInt(p+".checks.fast.x", 50) < x || oldZ+api.getFiles().getAC().getInt(p+".checks.fast.z", 50) < z) && !iAD(e, "mechanics", p+".checks.fast", false)) { 
         	ev.setCancelled(true);
-            double diffX = oldX+api.getFiles().getAC().getInt(p+".checks.fast.x", 45) - x;
+         if (FoliaScheduler.isFolia()) {
+        		FoliaScheduler.getGlobalRegionScheduler().run(api.getPlugin(), (FA) -> e.teleportAsync(oldL));
+        	} else {
+        		FoliaScheduler.getGlobalRegionScheduler().run(api.getPlugin(), (FA) -> e.teleport(oldL));
+        	}
             double diffY = oldY+api.getFiles().getAC().getInt(p+".checks.fast.y", 45) - y;
             double diffZ = oldZ+api.getFiles().getAC().getInt(p+".checks.fast.z", 45) - z;
         	flag(true, e, "Sending fast movement in a direction!", "Mechanics [Position]", "[X:"+diffX+", Y:"+diffY+", Z:"+diffZ+"]", api.getFiles().getAC().getInt(p+".checks.fast.vls", 1), "mechanics");
-        	FoliaScheduler.getGlobalRegionScheduler().run(api.getPlugin(), (FA) -> e.teleport(oldL));
+        	FoliaScheduler.getGlobalRegionScheduler().run(api.getPlugin(), (FA) -> e.teleportAsync(oldL));
         	if(api.getFiles().getAC().getBoolean(p+".checks.fast.kick", false)) timeOut(e);
         	return;
     	} else if (((pitch > 90 || pitch < -90) || !isNaN(pitch) || Double.isInfinite(pitch)) || (!(aYaw > 0.0 || aYaw < 360.0) || !isNaN(aYaw) || Double.isInfinite(aYaw)) && !iAD(e, "mechanics", p+".checks.yawpitch", true)) {

--- a/src/main/java/zoruafan/foxaddition/utils/FoxPlayer.java
+++ b/src/main/java/zoruafan/foxaddition/utils/FoxPlayer.java
@@ -44,9 +44,19 @@ public class FoxPlayer implements Listener {
     	try {
     		User u = (User) e;
     		u.sendPacket(new WrapperPlayServerDisconnect(reason));
-            if (e != null) { FoliaScheduler.getGlobalRegionScheduler().run(api.getPlugin(), (FA) -> e.kickPlayer("Disconnected")); }
+            if (e != null) { 
+            	if (FoliaScheduler.isFolia()) {
+            		e.getScheduler().run(api.getPlugin(), (FA) -> e.kickPlayer("Disconnected"), null);
+            	} else {
+            		FoliaScheduler.getGlobalRegionScheduler().run(api.getPlugin(), (FA) -> e.kickPlayer("Disconnected"));
+            	}
+            }
         } catch (Exception p) {
-        	FoliaScheduler.getGlobalRegionScheduler().run(api.getPlugin(), (FA) -> e.kickPlayer("Disconnected"));
+        	if (FoliaScheduler.isFolia()) {
+        		e.getScheduler().run(api.getPlugin(), (FA) -> e.kickPlayer("Disconnected"), null);
+        	} else {
+        		FoliaScheduler.getGlobalRegionScheduler().run(api.getPlugin(), (FA) -> e.kickPlayer("Disconnected"));
+        	}
         }
     }
     


### PR DESCRIPTION
- Replace synchronous teleport() with teleportAsync() on Folia in Position.java
- Add runtime Folia detection for proper teleport method selection
- Switch kickPlayer() calls to use entity scheduler on Folia instead of global scheduler
- Maintains full backward compatibility with Paper servers